### PR TITLE
Remove redundant deserialized_params method

### DIFF
--- a/lib/json_api_responders.rb
+++ b/lib/json_api_responders.rb
@@ -31,15 +31,6 @@ module JsonApiResponders
     Responder.new(self, nil, on_error: { status: status, detail: detail }).respond_error
   end
 
-  def deserialized_params
-    @_deserialized_options ||=
-      ActionController::Parameters.new(
-        ActiveModelSerializers::Deserialization.jsonapi_parse(
-          params, json_api_parse_options
-        )
-      )
-  end
-
   private
 
   def record_not_found!

--- a/lib/json_api_responders/version.rb
+++ b/lib/json_api_responders/version.rb
@@ -1,6 +1,6 @@
 module JsonApiResponders
   MAJOR = 2
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
   VERSION = [MAJOR, MINOR, PATCH].join('.').freeze
 end


### PR DESCRIPTION
This method isn't used anywhere and seems to be out of scope for the gem since it deals with Active Model Serializers.