### PR TITLE
Migrate CI to GH Actions, Fix Ruby 3 compatibility, Add ActiveModel dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.7, '3.0', 3.1]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,72 @@
+PATH
+  remote: .
+  specs:
+    json_api_responders (2.6.0)
+      activemodel
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.3)
+      activesupport (= 7.0.3)
+    activesupport (7.0.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    byebug (11.1.3)
+    codeclimate-test-reporter (1.0.9)
+      simplecov (<= 0.13)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
+    docile (1.1.5)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
+    json (2.6.1)
+    method_source (1.0.0)
+    minitest (5.15.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rack (2.2.3)
+    rake (10.5.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  codeclimate-test-reporter
+  json_api_responders!
+  pry-byebug
+  rack
+  rake (~> 10.0)
+  rspec
+  simplecov
+
+BUNDLED WITH
+   2.3.13

--- a/json_api_responders.gemspec
+++ b/json_api_responders.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   # spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rspec'
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_dependency 'activemodel'
 end

--- a/lib/json_api_responders.rb
+++ b/lib/json_api_responders.rb
@@ -1,3 +1,5 @@
+require 'active_model'
+
 require 'json_api_responders/version'
 require 'json_api_responders/errors'
 require 'json_api_responders/responder'
@@ -24,7 +26,7 @@ module JsonApiResponders
   def respond_with(resource, options = {})
     options = { params: params }.merge(options)
     JsonApiResponders.config.check_required_options(options)
-    Responder.new(self, resource, options).respond!
+    Responder.new(self, resource, **options).respond!
   end
 
   def respond_with_error(status, detail = nil)

--- a/lib/json_api_responders/responder.rb
+++ b/lib/json_api_responders/responder.rb
@@ -37,7 +37,7 @@ module JsonApiResponders
 
     def render_error
       controller.render(
-        render_options.merge(
+        **render_options.merge(
           json: error_render_options,
           status: error_status
         )
@@ -66,7 +66,7 @@ module JsonApiResponders
       errors[:errors] << { detail: on_error(:detail) } if on_error(:detail)
 
       if resource.respond_to?(:errors)
-        if ActiveModel.version >= Gem::Version.new("6.1")
+        if ::ActiveModel.version >= Gem::Version.new("6.1")
           resource.errors.each do |error|
             errors[:errors] << error_response(error.attribute, error.message)
           end

--- a/lib/json_api_responders/responder/actions.rb
+++ b/lib/json_api_responders/responder/actions.rb
@@ -35,7 +35,7 @@ module JsonApiResponders
 
       def respond_to_destroy_action
         self.status ||= :no_content
-        controller.head(status, render_options)
+        controller.head(status, **render_options)
       end
 
       def render_resource

--- a/spec/lib/json_api_responders/responder/actions_spec.rb
+++ b/spec/lib/json_api_responders/responder/actions_spec.rb
@@ -17,7 +17,7 @@ describe JsonApiResponders::Responder do
         errors: [
           {
             title: 'json_api.errors.unprocessable_entity.title',
-            detail: 'Name cant be blank',
+            detail: "Name can't be blank",
             source: { parameter: :name, pointer: 'data/attributes/name' }
           }
         ]

--- a/spec/lib/json_api_responders_spec.rb
+++ b/spec/lib/json_api_responders_spec.rb
@@ -47,7 +47,7 @@ describe JsonApiResponders do
           json: { errors: [
             { detail: 'Unauthorized' },
             { title: 'json_api.errors.unprocessable_entity.title',
-              detail: 'Name cant be blank',
+              detail: "Name can't be blank",
               source: { parameter: :name, pointer: 'data/attributes/name' } }
           ] }
         )

--- a/spec/support/fake_classes.rb
+++ b/spec/support/fake_classes.rb
@@ -20,31 +20,25 @@ class FakeController
 end
 
 class FakeModel
+  include ActiveModel::Model
+
   def errors
-    Message.new(name: 'cant be blank')
+    @errors ||= super.tap do |errors|
+      errors.add(:name, "can't be blank")
+    end
   end
 end
 
-class I18n
-  def self.t(transaltion)
-    transaltion
+module I18n
+  def self.t(translation, *args)
+    translation
   end
 end
 
-class Message
-  def initialize(hash)
-    @hash = hash
-  end
-
-  def each(&block)
-    @hash.each(&block)
-  end
-
-  def full_message(attribute, message)
-    "#{attribute.to_s.capitalize} #{message}"
-  end
-
-  def any?
-    @hash.any?
+module ActiveModel
+  class Errors
+    def full_message(attribute, message)
+      "#{attribute.to_s.humanize} #{message}"
+    end
   end
 end


### PR DESCRIPTION
CI currently runs on SemaphoreCI. This PR migrates the CI to GHA.

The gem is also incompatible with Ruby 3 because of some [keyword argument changes](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). The PR also fixes those issues.

Lastly, ActiveModel is used in the code, but it hasn't been added as a dependency, which has been fixed in the PR.