### PR TITLE
[CVE] Update gemspec and resolve CVEs in lockfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.1, 3.2, 3.3, 3.4]
+        ruby: [3.2, 3.3, 3.4]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, '3.0', 3.1]
+        ruby: [3.1, 3.2, 3.3, 3.4]
 
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,52 @@
 PATH
   remote: .
   specs:
-    json_api_responders (2.7.0)
+    json_api_responders (2.7.1)
       activemodel
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.3)
-      activesupport (= 7.0.3)
-    activesupport (7.0.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (7.2.2.2)
+      activesupport (= 7.2.2.2)
+    activesupport (7.2.2.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    byebug (11.1.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
+    byebug (12.0.0)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
     diff-lcs (1.5.0)
     docile (1.1.5)
+    drb (2.2.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
+    logger (1.7.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    pry (0.13.1)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
-    rack (2.2.3)
-    rake (10.5.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
+    rack (2.2.20)
+    rake (13.3.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -47,12 +60,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    securerandom (0.4.1)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
@@ -63,10 +77,10 @@ DEPENDENCIES
   codeclimate-test-reporter
   json_api_responders!
   pry-byebug
-  rack
-  rake (~> 10.0)
+  rack (< 3.0)
+  rake
   rspec
   simplecov
 
 BUNDLED WITH
-   2.3.13
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,4 +83,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.7.2
+   2.6.9

--- a/json_api_responders.gemspec
+++ b/json_api_responders.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   # spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rack'
+  spec.add_development_dependency 'rack', '< 3.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter'


### PR DESCRIPTION
### Background:

Name: activesupport
Version: 7.0.3
CVE: CVE-2023-22796
GHSA: GHSA-j6gc-792m-qgm2
Criticality: Unknown
URL: https://github.com/rails/rails/releases/tag/v7.0.4.1
Title: ReDoS based DoS vulnerability in Active Support’s underscore
Solution: upgrade to '~> 5.2.8', '~> 6.1.7, >= 6.1.7.1', '>= 7.0.4.1'

Name: activesupport
Version: 7.0.3
CVE: CVE-2023-28120
GHSA: GHSA-pj73-v5mw-pm9j
Criticality: Medium
URL: https://discuss.rubyonrails.org/t/cve-2023-28120-possible-xss-security-vulnerability-in-safebuffer-bytesplice/82469
Title: Possible XSS Security Vulnerability in SafeBuffer#bytesplice
Solution: upgrade to '~> 6.1.7, >= 6.1.7.3', '>= 7.0.4.3'

Name: activesupport
Version: 7.0.3
CVE: CVE-2023-38037
GHSA: GHSA-cr5q-6q9f-rq6q
Criticality: Medium
URL: https://github.com/rails/rails/releases/tag/v7.0.7.1
Title: Possible File Disclosure of Locally Encrypted Files
Solution: upgrade to '~> 6.1.7, >= 6.1.7.5', '>= 7.0.7.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-30122
GHSA: GHSA-hxqx-xwvh-44m2
Criticality: High
URL: https://groups.google.com/g/ruby-security-ann/c/L2Axto442qk
Title: Denial of Service Vulnerability in Rack Multipart Parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.1', '~> 2.1.4, >= 2.1.4.1', '>= 2.2.3.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-30123
GHSA: GHSA-wq4h-7r42-5hrr
Criticality: Critical
URL: https://groups.google.com/g/ruby-security-ann/c/LWB10kWzag8
Title: Possible shell escape sequence injection vulnerability in Rack
Solution: upgrade to '~> 2.0.9, >= 2.0.9.1', '~> 2.1.4, >= 2.1.4.1', '>= 2.2.3.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-44570
GHSA: GHSA-65f5-mfpf-vfhj
Criticality: High
URL: https://github.com/rack/rack/releases/tag/v3.0.4.1
Title: Denial of service via header parsing in Rack
Solution: upgrade to '~> 2.0.9, >= 2.0.9.2', '~> 2.1.4, >= 2.1.4.2', '~> 2.2.6, >= 2.2.6.2', '>= 3.0.4.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-44571
GHSA: GHSA-93pm-5p5f-3ghx
Criticality: Unknown
URL: https://github.com/rack/rack/releases/tag/v3.0.4.1
Title: Denial of Service Vulnerability in Rack Content-Disposition parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.2', '~> 2.1.4, >= 2.1.4.2', '~> 2.2.6, >= 2.2.6.1', '>= 3.0.4.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-44572
GHSA: GHSA-rqv2-275x-2jq5
Criticality: Unknown
URL: https://github.com/rack/rack/releases/tag/v3.0.4.1
Title: Denial of service via multipart parsing in Rack
Solution: upgrade to '~> 2.0.9, >= 2.0.9.2', '~> 2.1.4, >= 2.1.4.2', '~> 2.2.6, >= 2.2.6.1', '>= 3.0.4.1'

Name: rack
Version: 2.2.3
CVE: CVE-2023-27530
GHSA: GHSA-3h57-hmj3-gj3p
Criticality: High
URL: https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388
Title: Possible DoS Vulnerability in Multipart MIME parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.3', '~> 2.1.4, >= 2.1.4.3', '~> 2.2.6, >= 2.2.6.3', '>= 3.0.4.2'

Name: rack
Version: 2.2.3
CVE: CVE-2023-27539
GHSA: GHSA-c6qg-cjj8-47qp
Criticality: Unknown
URL: https://discuss.rubyonrails.org/t/cve-2023-27539-possible-denial-of-service-vulnerability-in-racks-header-parsing/82466
Title: Possible Denial of Service Vulnerability in Rack’s header parsing
Solution: upgrade to '~> 2.0, >= 2.2.6.4', '>= 3.0.6.1'

Name: rack
Version: 2.2.3
CVE: CVE-2024-25126
GHSA: GHSA-22f2-v57c-j9cx
Criticality: Medium
URL: https://discuss.rubyonrails.org/t/denial-of-service-vulnerability-in-rack-content-type-parsing/84941
Title: Denial of Service Vulnerability in Rack Content-Type Parsing
Solution: upgrade to '~> 2.2.8, >= 2.2.8.1', '>= 3.0.9.1'

Name: rack
Version: 2.2.3
CVE: CVE-2024-26141
GHSA: GHSA-xj5v-6v4g-jfw6
Criticality: Unknown
URL: https://discuss.rubyonrails.org/t/possible-dos-vulnerability-with-range-header-in-rack/84944
Title: Possible DoS Vulnerability with Range Header in Rack
Solution: upgrade to '~> 2.2.8, >= 2.2.8.1', '>= 3.0.9.1'

Name: rack
Version: 2.2.3
CVE: CVE-2024-26146
GHSA: GHSA-54rr-7fvw-6x8f
Criticality: Unknown
URL: https://discuss.rubyonrails.org/t/possible-denial-of-service-vulnerability-in-rack-header-parsing/84942
Title: Possible Denial of Service Vulnerability in Rack Header Parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.4', '~> 2.1.4, >= 2.1.4.4', '~> 2.2.8, >= 2.2.8.1', '>= 3.0.9.1'

Name: rack
Version: 2.2.3
CVE: CVE-2025-25184
GHSA: GHSA-7g2v-jj9q-g3rg
Criticality: Medium
URL: https://github.com/rack/rack/security/advisories/GHSA-7g2v-jj9q-g3rg
Title: Possible Log Injection in Rack::CommonLogger
Solution: upgrade to '~> 2.2.11', '~> 3.0.12', '>= 3.1.10'

Name: rack
Version: 2.2.3
CVE: CVE-2025-27111
GHSA: GHSA-8cgq-6mh2-7j6v
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-8cgq-6mh2-7j6v
Title: Escape Sequence Injection vulnerability in Rack lead to Possible Log Injection
Solution: upgrade to '~> 2.2.12', '~> 3.0.13', '>= 3.1.11'

Name: rack
Version: 2.2.3
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: upgrade to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'

Name: rack
Version: 2.2.3
CVE: CVE-2025-32441
GHSA: GHSA-vpfw-47h7-xj4g
Criticality: Medium
URL: https://github.com/rack/rack-session/security/advisories/GHSA-9j94-67jr-4cqj
Title: Rack session gets restored after deletion
Solution: upgrade to '>= 2.2.14'

Name: rack
Version: 2.2.3
CVE: CVE-2025-46727
GHSA: GHSA-gjh7-p2fx-99vx
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-gjh7-p2fx-99vx
Title: Rack has an Unbounded-Parameter DoS in Rack::QueryParser
Solution: upgrade to '~> 2.2.14', '~> 3.0.16', '>= 3.1.14'

Name: rack
Version: 2.2.3
CVE: CVE-2025-59830
GHSA: GHSA-625h-95r8-8xpm
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-625h-95r8-8xpm
Title: Rack has an unsafe default in Rack::QueryParser allows params_limit bypass via semicolon-separated parameters
Solution: upgrade to '>= 2.2.18'

Name: rack
Version: 2.2.3
CVE: CVE-2025-61770
GHSA: GHSA-p543-xpfm-54cp
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-p543-xpfm-54cp
Title: Rack's unbounded multipart preamble buffering enables DoS (memory exhaustion)
Solution: upgrade to '~> 2.2.19', '~> 3.1.17', '>= 3.2.2'

Name: rack
Version: 2.2.3
CVE: CVE-2025-61771
GHSA: GHSA-w9pc-fmgc-vxvw
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-w9pc-fmgc-vxvw
Title: Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)
Solution: upgrade to '~> 2.2.19', '~> 3.1.17', '>= 3.2.2'

Name: rack
Version: 2.2.3
CVE: CVE-2025-61772
GHSA: GHSA-wpv5-97wm-hp9c
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-wpv5-97wm-hp9c
Title: Rack's multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)
Solution: upgrade to '~> 2.2.19', '~> 3.1.17', '>= 3.2.2'

Name: rack
Version: 2.2.3
CVE: CVE-2025-61780
GHSA: GHSA-r657-rxjc-j557
Criticality: Medium
URL: https://github.com/rack/rack/security/advisories/GHSA-r657-rxjc-j557
Title: Rack has a Possible Information Disclosure Vulnerability
Solution: upgrade to '~> 2.2.20', '~> 3.1.18', '>= 3.2.3'

Name: rack
Version: 2.2.3
CVE: CVE-2025-61919
GHSA: GHSA-6xw4-3v39-52mm
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-6xw4-3v39-52mm
Title: Rack is vulnerable to a memory-exhaustion DoS through unbounded URL-encoded body parsing
Solution: upgrade to '~> 2.2.20', '~> 3.1.18', '>= 3.2.3'

Name: rake
Version: 10.5.0
CVE: CVE-2020-8130
GHSA: GHSA-jppv-gw3r-w3q8
Criticality: High
URL: https://github.com/advisories/GHSA-jppv-gw3r-w3q8
Title: OS Command Injection in Rake
Solution: upgrade to '>= 12.3.3'

### Solution
* Updated bunlder
* Updated Gemfile.lock to resolve CVEs
* Added a version constraint to the `rack` development dependency, restricting it to versions below 3.0 to prevent compatibility issues with breaking changes in `rack` 3.x.